### PR TITLE
Updated gulp-load-plugins to version 1.0.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gulp-imagemin": "2.3.0",
     "gulp-jscs": "3.0.0",
     "gulp-jshint": "1.11.2",
-    "gulp-load-plugins": "0.10.0",
+    "gulp-load-plugins": "1.0.0-rc.1",
     "gulp-minify-html": "1.0.4",
     "gulp-postcss": "6.0.0",
     "gulp-rev": "6.0.1",


### PR DESCRIPTION
:rocket:

gulp-load-plugins just published version 1.0.0-rc.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 5 commits (ahead by 5, behind by 0).
- [22fb861](https://github.com/jackfranklin/gulp-load-plugins/commit/22fb861f31bb5031b4e1e0ff992bcd77edfe6c3e): V1 rc1
- [46aae24](https://github.com/jackfranklin/gulp-load-plugins/commit/46aae2404c606ad8a3685e485b47377eecc15a55): Merge pull request #75 from callumacrae/resolve
- [e8f81ee](https://github.com/jackfranklin/gulp-load-plugins/commit/e8f81eef56e406f229f02a4f1f6bbde0d67c980f): Replaced findup with resolve. Dropped support for NODE_PATH :/
- [ef31ce6](https://github.com/jackfranklin/gulp-load-plugins/commit/ef31ce655d19a4e66febc9dfb56c0df7c4693df5): Merge pull request #73 from passy/patch-2
- [362ccc9](https://github.com/jackfranklin/gulp-load-plugins/commit/362ccc9bd8c7c524881cf8a6ea627cfc5a87c649): Update README

See the [full diff](https://github.com/jackfranklin/gulp-load-plugins/compare/6fbf3f0edc77335f0f828b1cf710b1e6e352764f...22fb861f31bb5031b4e1e0ff992bcd77edfe6c3e).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
