### PR TITLE
Updated gulp-sane-watch to version 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gulp-postcss": "6.0.1",
     "gulp-rev": "6.0.1",
     "gulp-rev-replace": "0.4.2",
-    "gulp-sane-watch": "1.0.2",
+    "gulp-sane-watch": "1.0.3",
     "gulp-sass": "2.0.4",
     "gulp-size": "2.0.0",
     "gulp-sourcemaps": "1.6.0",


### PR DESCRIPTION
:rocket:

gulp-sane-watch just published version 1.0.3, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 3 commits (ahead by 3, behind by 0).
- [479ff86](https://github.com/ggkovacs/gulp-sane-watch/commit/479ff86a65eb69743475680567fd6de5a227a41a): bump version
- [4217d25](https://github.com/ggkovacs/gulp-sane-watch/commit/4217d25a1e807f453777d8bd4fec90024bb82ffc): Merge pull request #5 from ggkovacs/greenkeeper-pin
- [5bfc072](https://github.com/ggkovacs/gulp-sane-watch/commit/5bfc0729fd4837d7f47dd4c262a19c3adc6f0679): chore(package): pin dependencies

See the [full diff](https://github.com/ggkovacs/gulp-sane-watch/compare/a05bb284298d2e243605f50b9f00e495d99f5842...479ff86a65eb69743475680567fd6de5a227a41a).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
