### PR TITLE
Updated browser-sync to version 2.9.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "apache-server-configs": "2.14.0",
     "autoprefixer": "6.0.3",
     "babel-core": "5.8.25",
-    "browser-sync": "2.9.8",
+    "browser-sync": "2.9.9",
     "del": "2.0.2",
     "gulp": "3.9.0",
     "gulp-cache": "0.3.0",


### PR DESCRIPTION
:rocket:

browser-sync just published version 2.9.9, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 3 commits (ahead by 3, behind by 0).
- [fe716bb](https://github.com/BrowserSync/browser-sync/commit/fe716bb382172df638bbea74aea6e6f988e80515): 2.9.9
- [01056c5](https://github.com/BrowserSync/browser-sync/commit/01056c5b8f9a4f9aaa644b1c9960094e98d2d443): deps: bump browser-sync-client@2.3.2 for fixes relating to #449
- [12095f3](https://github.com/BrowserSync/browser-sync/commit/12095f376279b82214da87231efc9d7943f1719b): deps: pin meow@3.3 until https://github.com/sindresorhus/meow/issues/11 is resolved

See the [full diff](https://github.com/BrowserSync/browser-sync/compare/1d86f1a8bae3d9228f732d3022644c2ebe521186...fe716bb382172df638bbea74aea6e6f988e80515).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
